### PR TITLE
Update core addon lists

### DIFF
--- a/news/71.feature
+++ b/news/71.feature
@@ -1,0 +1,1 @@
+Update core addon lists.

--- a/src/manifestoo_core/core_addons/addons-14.0-c.txt
+++ b/src/manifestoo_core/core_addons/addons-14.0-c.txt
@@ -1,4 +1,4 @@
-# generated on Fri Mar 15 20:05:06 2024
+# generated on Tue May 14 15:22:27 2024
 account
 account_check_printing
 account_debit_note

--- a/src/manifestoo_core/core_addons/addons-14.0-e.txt
+++ b/src/manifestoo_core/core_addons/addons-14.0-e.txt
@@ -1,4 +1,4 @@
-# generated on Fri Mar 15 20:05:24 2024
+# generated on Tue May 14 15:22:41 2024
 account_3way_match
 account_accountant
 account_accountant_check_printing

--- a/src/manifestoo_core/core_addons/addons-15.0-c.txt
+++ b/src/manifestoo_core/core_addons/addons-15.0-c.txt
@@ -1,4 +1,4 @@
-# generated on Fri Mar 15 20:04:23 2024
+# generated on Tue May 14 15:21:47 2024
 account
 account_check_printing
 account_debit_note

--- a/src/manifestoo_core/core_addons/addons-15.0-e.txt
+++ b/src/manifestoo_core/core_addons/addons-15.0-e.txt
@@ -1,4 +1,4 @@
-# generated on Fri Mar 15 20:04:38 2024
+# generated on Tue May 14 15:22:00 2024
 account_3way_match
 account_accountant
 account_accountant_batch_payment

--- a/src/manifestoo_core/core_addons/addons-16.0-c.txt
+++ b/src/manifestoo_core/core_addons/addons-16.0-c.txt
@@ -1,4 +1,4 @@
-# generated on Fri Mar 15 20:03:36 2024
+# generated on Tue May 14 15:20:58 2024
 account
 account_check_printing
 account_debit_note

--- a/src/manifestoo_core/core_addons/addons-16.0-e.txt
+++ b/src/manifestoo_core/core_addons/addons-16.0-e.txt
@@ -1,4 +1,4 @@
-# generated on Fri Mar 15 20:03:53 2024
+# generated on Tue May 14 15:21:14 2024
 account_3way_match
 account_accountant
 account_accountant_batch_payment
@@ -27,6 +27,7 @@ account_invoice_extract
 account_invoice_extract_purchase
 account_online_synchronization
 account_predictive_bills
+account_reconcile_wizard
 account_reports
 account_reports_cash_basis
 account_reports_tax_reminder
@@ -248,6 +249,8 @@ l10n_nl_intrastat
 l10n_nl_reports
 l10n_nl_reports_sbr
 l10n_nl_reports_sbr_icp
+l10n_nl_reports_sbr_ob_nummer
+l10n_nl_reports_sbr_status_info
 l10n_no_reports
 l10n_no_saft
 l10n_pe_edi

--- a/src/manifestoo_core/core_addons/addons-17.0-c.txt
+++ b/src/manifestoo_core/core_addons/addons-17.0-c.txt
@@ -1,4 +1,4 @@
-# generated on Fri Mar 15 20:02:50 2024
+# generated on Tue May 14 15:20:20 2024
 account
 account_audit_trail
 account_check_printing
@@ -114,15 +114,22 @@ l10n_at
 l10n_au
 l10n_be
 l10n_be_pos_sale
+l10n_bf
 l10n_bg
+l10n_bj
 l10n_bo
 l10n_br
 l10n_br_pix
 l10n_br_sales
 l10n_br_website_sale
 l10n_ca
+l10n_cd
+l10n_cf
+l10n_cg
 l10n_ch
+l10n_ci
 l10n_cl
+l10n_cm
 l10n_cn
 l10n_cn_city
 l10n_co
@@ -163,16 +170,21 @@ l10n_fr_fec
 l10n_fr_hr_holidays
 l10n_fr_hr_work_entry_holidays
 l10n_fr_pos_cert
+l10n_ga
 l10n_gcc_invoice
 l10n_gcc_invoice_stock_account
 l10n_gcc_pos
+l10n_gn
+l10n_gq
 l10n_gr
 l10n_gt
+l10n_gw
 l10n_hk
 l10n_hn
 l10n_hr
 l10n_hr_kuna
 l10n_hu
+l10n_hu_edi
 l10n_id
 l10n_id_efaktur
 l10n_ie
@@ -195,6 +207,7 @@ l10n_jp
 l10n_jp_ubl_pint
 l10n_ke
 l10n_ke_edi_tremol
+l10n_km
 l10n_kz
 l10n_latam_base
 l10n_latam_check
@@ -203,11 +216,17 @@ l10n_lt
 l10n_lu
 l10n_lv
 l10n_ma
+l10n_ml
 l10n_mn
+l10n_mt
+l10n_mu_account
 l10n_mx
 l10n_mx_hr
 l10n_my
+l10n_my_ubl_pint
 l10n_mz
+l10n_ne
+l10n_ng
 l10n_nl
 l10n_no
 l10n_nz
@@ -222,6 +241,7 @@ l10n_pt
 l10n_ro
 l10n_ro_edi
 l10n_rs
+l10n_rw
 l10n_sa
 l10n_sa_edi
 l10n_sa_pos
@@ -229,7 +249,10 @@ l10n_se
 l10n_sg
 l10n_si
 l10n_sk
+l10n_sn
 l10n_syscohada
+l10n_td
+l10n_tg
 l10n_th
 l10n_tn
 l10n_tr
@@ -311,6 +334,7 @@ pos_epson_printer
 pos_hr
 pos_hr_restaurant
 pos_loyalty
+pos_mercado_pago
 pos_mercury
 pos_mrp
 pos_online_payment
@@ -360,6 +384,7 @@ rating
 repair
 resource
 sale
+sale_async_emails
 sale_crm
 sale_expense
 sale_expense_margin

--- a/src/manifestoo_core/core_addons/addons-17.0-e.txt
+++ b/src/manifestoo_core/core_addons/addons-17.0-e.txt
@@ -1,4 +1,4 @@
-# generated on Fri Mar 15 20:03:07 2024
+# generated on Tue May 14 15:20:36 2024
 account_3way_match
 account_accountant
 account_accountant_batch_payment
@@ -192,9 +192,13 @@ l10n_be_us_consolidation_demo
 l10n_bg_reports
 l10n_bo_reports
 l10n_br_avatax
+l10n_br_avatax_services
 l10n_br_edi
 l10n_br_edi_sale
+l10n_br_edi_sale_services
+l10n_br_edi_services
 l10n_br_reports
+l10n_br_sale_subscription
 l10n_br_test_avatax_sale
 l10n_ca_check_printing
 l10n_ca_reports
@@ -267,6 +271,7 @@ l10n_ma_hr_payroll
 l10n_ma_hr_payroll_account
 l10n_ma_reports
 l10n_mn_reports
+l10n_mt_reports
 l10n_mx_edi
 l10n_mx_edi_extended
 l10n_mx_edi_landing
@@ -282,13 +287,17 @@ l10n_mx_hr_payroll_account
 l10n_mx_reports
 l10n_mx_reports_closing
 l10n_mx_xml_polizas
+l10n_my_reports
 l10n_mz_reports
+l10n_ng_reports
 l10n_nl_hr_payroll
 l10n_nl_hr_payroll_account
 l10n_nl_intrastat
 l10n_nl_reports
 l10n_nl_reports_sbr
 l10n_nl_reports_sbr_icp
+l10n_nl_reports_sbr_ob_nummer
+l10n_nl_reports_sbr_status_info
 l10n_no_reports
 l10n_no_saft
 l10n_pe_edi
@@ -307,6 +316,7 @@ l10n_ro_reports
 l10n_ro_saft
 l10n_ro_saft_import
 l10n_rs_reports
+l10n_rw_reports
 l10n_sa_hr_payroll
 l10n_sa_hr_payroll_account
 l10n_se_reports


### PR DESCRIPTION
Used https://github.com/acsone/manifestoo-core/blob/main/mk_core_addons until it tried to force-push to here, then ran the rest manually.

Our build system does `pip install -e /odoo/enterprise`, and that is broken due to at least `l10n_ng` not being listed in `manifestoo-core`.