### PR TITLE
Update core addon lists

### DIFF
--- a/src/manifestoo_core/core_addons/addons-14.0-c.txt
+++ b/src/manifestoo_core/core_addons/addons-14.0-c.txt
@@ -1,4 +1,4 @@
-# generated on Tue May 14 15:22:27 2024
+# generated on Mon Jul 15 11:05:04 2024
 account
 account_check_printing
 account_debit_note

--- a/src/manifestoo_core/core_addons/addons-14.0-e.txt
+++ b/src/manifestoo_core/core_addons/addons-14.0-e.txt
@@ -1,4 +1,4 @@
-# generated on Tue May 14 15:22:41 2024
+# generated on Mon Jul 15 11:05:19 2024
 account_3way_match
 account_accountant
 account_accountant_check_printing

--- a/src/manifestoo_core/core_addons/addons-15.0-c.txt
+++ b/src/manifestoo_core/core_addons/addons-15.0-c.txt
@@ -1,4 +1,4 @@
-# generated on Tue May 14 15:21:47 2024
+# generated on Mon Jul 15 11:04:25 2024
 account
 account_check_printing
 account_debit_note
@@ -150,6 +150,7 @@ l10n_fi_sale
 l10n_fr
 l10n_fr_facturx_chorus_pro
 l10n_fr_fec
+l10n_fr_invoice_addr
 l10n_fr_pos_cert
 l10n_gcc_invoice
 l10n_gcc_invoice_stock_account

--- a/src/manifestoo_core/core_addons/addons-15.0-e.txt
+++ b/src/manifestoo_core/core_addons/addons-15.0-e.txt
@@ -1,4 +1,4 @@
-# generated on Tue May 14 15:22:00 2024
+# generated on Mon Jul 15 11:04:39 2024
 account_3way_match
 account_accountant
 account_accountant_batch_payment
@@ -34,6 +34,7 @@ account_reports_tax_reminder
 account_saft
 account_sepa
 account_sepa_direct_debit
+account_sepa_direct_debit_008_001_08
 account_sepa_pain_001_001_09
 account_taxcloud
 account_winbooks_import
@@ -154,6 +155,7 @@ l10n_be_intrastat
 l10n_be_reports
 l10n_be_reports_base_address_extended
 l10n_be_reports_post_wizard
+l10n_be_reports_prorata
 l10n_be_reports_sms
 l10n_be_us_consolidation_demo
 l10n_bg_reports
@@ -202,6 +204,7 @@ l10n_mx_edi_stock_30
 l10n_mx_edi_stock_40
 l10n_mx_edi_stock_extended
 l10n_mx_edi_stock_extended_30
+l10n_mx_edi_stock_extended_31
 l10n_mx_edi_stock_extended_40
 l10n_mx_reports
 l10n_mx_reports_closing

--- a/src/manifestoo_core/core_addons/addons-16.0-c.txt
+++ b/src/manifestoo_core/core_addons/addons-16.0-c.txt
@@ -1,4 +1,4 @@
-# generated on Tue May 14 15:20:58 2024
+# generated on Mon Jul 15 11:03:43 2024
 account
 account_check_printing
 account_debit_note
@@ -115,6 +115,7 @@ l10n_bo
 l10n_br
 l10n_ca
 l10n_ch
+l10n_ch_pos
 l10n_cl
 l10n_cn
 l10n_cn_city
@@ -147,6 +148,7 @@ l10n_fi_sale
 l10n_fr
 l10n_fr_facturx_chorus_pro
 l10n_fr_fec
+l10n_fr_invoice_addr
 l10n_fr_pos_cert
 l10n_gcc_invoice
 l10n_gcc_invoice_stock_account

--- a/src/manifestoo_core/core_addons/addons-16.0-e.txt
+++ b/src/manifestoo_core/core_addons/addons-16.0-e.txt
@@ -1,4 +1,4 @@
-# generated on Tue May 14 15:21:14 2024
+# generated on Mon Jul 15 11:03:58 2024
 account_3way_match
 account_accountant
 account_accountant_batch_payment
@@ -34,6 +34,7 @@ account_reports_tax_reminder
 account_saft
 account_sepa
 account_sepa_direct_debit
+account_sepa_direct_debit_008_001_08
 account_sepa_pain_001_001_09
 account_taxcloud
 account_winbooks_import
@@ -168,6 +169,7 @@ l10n_be_hr_payroll_fleet
 l10n_be_intrastat
 l10n_be_reports
 l10n_be_reports_post_wizard
+l10n_be_reports_prorata
 l10n_be_reports_sms
 l10n_be_soda
 l10n_be_us_consolidation_demo
@@ -240,6 +242,7 @@ l10n_mx_edi_stock_30
 l10n_mx_edi_stock_40
 l10n_mx_edi_stock_extended
 l10n_mx_edi_stock_extended_30
+l10n_mx_edi_stock_extended_31
 l10n_mx_edi_stock_extended_40
 l10n_mx_reports
 l10n_mx_reports_closing

--- a/src/manifestoo_core/core_addons/addons-17.0-c.txt
+++ b/src/manifestoo_core/core_addons/addons-17.0-c.txt
@@ -1,4 +1,4 @@
-# generated on Tue May 14 15:20:20 2024
+# generated on Mon Jul 15 11:03:02 2024
 account
 account_audit_trail
 account_check_printing
@@ -112,6 +112,7 @@ l10n_ar_website_sale
 l10n_ar_withholding
 l10n_at
 l10n_au
+l10n_bd
 l10n_be
 l10n_be_pos_sale
 l10n_bf
@@ -127,6 +128,7 @@ l10n_cd
 l10n_cf
 l10n_cg
 l10n_ch
+l10n_ch_pos
 l10n_ci
 l10n_cl
 l10n_cm
@@ -137,6 +139,7 @@ l10n_co_pos
 l10n_cr
 l10n_cz
 l10n_de
+l10n_de_audit_trail
 l10n_din5008
 l10n_din5008_purchase
 l10n_din5008_repair
@@ -160,6 +163,7 @@ l10n_es_edi_facturae_invoice_period
 l10n_es_edi_sii
 l10n_es_edi_tbai
 l10n_es_pos
+l10n_es_pos_tbai
 l10n_et
 l10n_eu_oss
 l10n_fi
@@ -169,6 +173,7 @@ l10n_fr_facturx_chorus_pro
 l10n_fr_fec
 l10n_fr_hr_holidays
 l10n_fr_hr_work_entry_holidays
+l10n_fr_invoice_addr
 l10n_fr_pos_cert
 l10n_ga
 l10n_gcc_invoice
@@ -192,6 +197,7 @@ l10n_il
 l10n_in
 l10n_in_edi
 l10n_in_edi_ewaybill
+l10n_in_ewaybill_stock
 l10n_in_pos
 l10n_in_purchase
 l10n_in_purchase_stock
@@ -200,6 +206,7 @@ l10n_in_sale_stock
 l10n_in_stock
 l10n_it
 l10n_it_edi
+l10n_it_edi_doi
 l10n_it_edi_website_sale
 l10n_it_edi_withholding
 l10n_it_stock_ddt
@@ -240,6 +247,7 @@ l10n_pl
 l10n_pt
 l10n_ro
 l10n_ro_edi
+l10n_ro_efactura
 l10n_rs
 l10n_rw
 l10n_sa
@@ -257,6 +265,7 @@ l10n_th
 l10n_tn
 l10n_tr
 l10n_tw
+l10n_tz_account
 l10n_ua
 l10n_ug
 l10n_uk

--- a/src/manifestoo_core/core_addons/addons-17.0-e.txt
+++ b/src/manifestoo_core/core_addons/addons-17.0-e.txt
@@ -1,7 +1,8 @@
-# generated on Tue May 14 15:20:36 2024
+# generated on Mon Jul 15 11:03:17 2024
 account_3way_match
 account_accountant
 account_accountant_batch_payment
+account_accountant_check_printing
 account_accountant_fleet
 account_asset
 account_asset_fleet
@@ -186,6 +187,7 @@ l10n_be_hr_payroll_sd_worx
 l10n_be_intrastat
 l10n_be_reports
 l10n_be_reports_post_wizard
+l10n_be_reports_prorata
 l10n_be_reports_sms
 l10n_be_soda
 l10n_be_us_consolidation_demo
@@ -204,6 +206,7 @@ l10n_ca_check_printing
 l10n_ca_reports
 l10n_ch_hr_payroll
 l10n_ch_hr_payroll_account
+l10n_ch_hr_payroll_elm
 l10n_ch_reports
 l10n_cl_edi
 l10n_cl_edi_boletas
@@ -227,6 +230,7 @@ l10n_dk_saft_import
 l10n_do_reports
 l10n_dz_reports
 l10n_ec_edi
+l10n_ec_edi_pos
 l10n_ec_reports
 l10n_ec_reports_ats
 l10n_ee_reports
@@ -254,6 +258,9 @@ l10n_in_reports_gstr
 l10n_in_reports_gstr_pos
 l10n_in_reports_gstr_spreadsheet
 l10n_it_reports
+l10n_ke_edi_oscu
+l10n_ke_edi_oscu_mrp
+l10n_ke_edi_oscu_stock
 l10n_ke_hr_payroll
 l10n_ke_hr_payroll_account
 l10n_ke_reports
@@ -281,6 +288,7 @@ l10n_mx_edi_stock
 l10n_mx_edi_stock_30
 l10n_mx_edi_stock_extended
 l10n_mx_edi_stock_extended_30
+l10n_mx_edi_stock_extended_31
 l10n_mx_edi_website_sale
 l10n_mx_hr_payroll
 l10n_mx_hr_payroll_account
@@ -330,6 +338,7 @@ l10n_th_reports
 l10n_tn_reports
 l10n_tr_reports
 l10n_tw_reports
+l10n_tz_reports
 l10n_uk_customer_statements
 l10n_uk_reports
 l10n_us_1099
@@ -380,6 +389,7 @@ pos_pricer
 pos_restaurant_appointment
 pos_restaurant_preparation_display
 pos_sale_stock_renting
+pos_sale_subscription
 pos_self_order_iot
 pos_self_order_preparation_display
 pos_settle_due
@@ -531,6 +541,7 @@ website_sale_external_tax
 website_sale_fedex
 website_sale_renting
 website_sale_renting_product_configurator
+website_sale_shiprocket
 website_sale_stock_renting
 website_sale_subscription
 website_sale_ups


### PR DESCRIPTION
Basically the same as #71

Odoo has added at least `l10n_tz_account` to the core modules, and installing Enterprise once again breaks.