### PR TITLE
[FIX] addon_name_to_distribution_name should replace '_' in addon_name by '-'

### DIFF
--- a/src/manifestoo_core/metadata.py
+++ b/src/manifestoo_core/metadata.py
@@ -334,7 +334,7 @@ def _addon_name_to_metadata_name(
 def addon_name_to_distribution_name(addon_name: str, odoo_series: OdooSeries) -> str:
     """Convert an Odoo addon name to the corresponding packaging distribution name."""
     return _addon_name_to_metadata_name(
-        addon_name,
+        addon_name.replace("_", "-"),
         OdooSeriesInfo.from_odoo_series(odoo_series),
     )
 

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -742,7 +742,7 @@ def test_addon_name_to_distribution_name() -> None:
     )
     assert (
         addon_name_to_distribution_name("addon_1", OdooSeries.v16_0)
-        == "odoo-addon-addon_1"
+        == "odoo-addon-addon-1"
     )
 
 


### PR DESCRIPTION
  Example:
    addon name: `test_addon`
    odoo version: `16.0`

- How it was:
    addon_name_todistribution_name returns: `odoo-addon-test_addon`

- How it is now:
    addon_name_todistribution_name returns: `odoo-addon-test-addon`