### PR TITLE
Handle markdown and plain text readme too and include content type in metadata

### DIFF
--- a/news/79.feature.md
+++ b/news/79.feature.md
@@ -1,0 +1,1 @@
+Description can now also be a README.md, a README.txt or extracted from manifest. Mimetype of the description metadata is set accordingly.

--- a/src/manifestoo_core/metadata.py
+++ b/src/manifestoo_core/metadata.py
@@ -159,9 +159,11 @@ def metadata_from_addon_dir(
     _set("Author", _no_nl(manifest.author))
     _set("Author-email", _author_email(manifest.author))
     _set("Classifier", _make_classifiers(odoo_series, manifest))
-    long_description = _long_description(addon)
+    long_description, long_description_content_type = _long_description(addon)
     if long_description:
         meta.set_payload(long_description)
+    if long_description_content_type:
+        _set("Description-Content-Type", long_description_content_type)
 
     return meta
 
@@ -368,11 +370,20 @@ def _no_nl(s: Optional[str]) -> Optional[str]:
     return " ".join(s.split())
 
 
-def _long_description(addon: Addon) -> Optional[str]:
+def _long_description(addon: Addon) -> Tuple[Optional[str], Optional[str]]:
+    """
+    :return: a tuple with long description and its content type
+    """
     readme_path = addon.path / "README.rst"
     if readme_path.is_file():
-        return readme_path.read_text(encoding="utf-8")
-    return addon.manifest.description
+        return readme_path.read_text(encoding="utf-8"), "text/x-rst"
+    readme_path = addon.path / "README.md"
+    if readme_path.is_file():
+        return readme_path.read_text(encoding="utf-8"), "text/markdown"
+    readme_path = addon.path / "README.txt"
+    if readme_path.is_file():
+        return readme_path.read_text(encoding="utf-8"), "text/plain"
+    return addon.manifest.description, "text/x-rst"
 
 
 def _make_classifiers(odoo_series: OdooSeries, manifest: Manifest) -> List[str]:

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -40,6 +40,7 @@ def _m(  # noqa: PLR0913 too many arguments
     summary: Optional[str] = None,
     description: Optional[str] = None,
     readme_rst: Optional[str] = None,
+    readme_md: Optional[str] = None,
     depends: Optional[List[str]] = None,
     external_dependencies: Optional[Dict[str, List[str]]] = None,
     website: Optional[str] = None,
@@ -82,6 +83,9 @@ def _m(  # noqa: PLR0913 too many arguments
     if readme_rst:
         readme_path = addon_dir / "README.rst"
         readme_path.write_text(readme_rst)
+    if readme_md:
+        readme_path = addon_dir / "README.md"
+        readme_path.write_text(readme_md)
     return msg_to_json(
         metadata_from_addon_dir(
             addon_dir,
@@ -111,6 +115,7 @@ def test_basic(tmp_path: Path) -> None:
             "Framework :: Odoo :: 14.0",
         ],
         "metadata_version": "2.1",
+        "description_content_type": "text/x-rst",
     }
 
 
@@ -333,7 +338,18 @@ def test_description_from_readme(
     tmp_path: Path,
     readme_rst: str = "A readme\n\nwith two lines",
 ) -> None:
-    assert _m(tmp_path, readme_rst=readme_rst)["description"] == readme_rst
+    m = _m(tmp_path, readme_rst=readme_rst)
+    assert m["description"] == readme_rst
+    assert m["description_content_type"] == "text/x-rst"
+
+
+def test_description_from_readme_md(
+    tmp_path: Path,
+    readme_md: str = "A readme\n\nwith two lines",
+) -> None:
+    m = _m(tmp_path, readme_md=readme_md)
+    assert m["description"] == readme_md
+    assert m["description_content_type"] == "text/markdown"
 
 
 def test_description_from_description_and_readme(
@@ -341,10 +357,9 @@ def test_description_from_description_and_readme(
     description: str = "A description",
     readme_rst: str = "A readme\n\nwith two lines",
 ) -> None:
-    assert (
-        _m(tmp_path, description=description, readme_rst=readme_rst)["description"]
-        == readme_rst
-    )
+    m = _m(tmp_path, description=description, readme_rst=readme_rst)
+    assert m["description"] == readme_rst
+    assert m["description_content_type"] == "text/x-rst"
 
 
 def test_author(tmp_path: Path) -> None:


### PR DESCRIPTION
This is a new feature to match what Odoo does with readme file and module descriptions.